### PR TITLE
Added ability to exclude sub-pages, like thank_you/index.html.

### DIFF
--- a/sitemap_generator.rb
+++ b/sitemap_generator.rb
@@ -47,6 +47,7 @@ module Jekyll
   SITEMAP_FILE_NAME = "sitemap.xml"
 
   # Any files to exclude from being included in the sitemap.xml
+  # e.g. 404.html or thank_you/index.html
   EXCLUDED_FILES = ["atom.xml"]
 
   # Any files that include posts, so that when a new post is added, the last
@@ -81,6 +82,10 @@ module Jekyll
     def location_on_server(my_url)
       location = "#{my_url}#{@dir}#{url}"
       location.gsub(/index.html$/, "")
+    end
+
+    def file_path
+      location = "#{@dir}#{url}".gsub(/^\//, "")
     end
   end
 
@@ -164,7 +169,7 @@ module Jekyll
     # Returns last_modified_date of index page
     def fill_pages(site, urlset)
       site.pages.each do |page|
-        if !excluded?(page.name)
+        if !excluded?(page.file_path)
           path = page.full_path_to_source
           if File.exists?(path)
             url = fill_url(site, page)


### PR DESCRIPTION
The current implementation of `EXCLUDE_FILES` doesn't allow excluding pages that are within subdirectories, because it only compares the array constant with `page.name`.

For example, I like having pretty URLs, so instead of `some_page.html`, I have `some_page/index.html`. That means for all my pages:

```
page.name #=> "index.html"
```

So, I can either put "index.html" in `EXCLUDE_FILES` and it will exclude every page from the sitemap, or don't put that and it will include all of them.

I added a `page.file_path` method and pass that into the `excluded?` method instead of the page name. It returns the relative path of the file without the leading slash. So, it's identical to `path.name` for files in the root directory, but includes the directory name otherwise.
