### PR TITLE
Remove the dir to stop getting double directories

### DIFF
--- a/sitemap_generator.rb
+++ b/sitemap_generator.rb
@@ -79,7 +79,7 @@ module Jekyll
     end
 
     def location_on_server(my_url)
-      location = "#{my_url}#{@dir}#{url}"
+      location = "#{my_url}#{url}"
       location.gsub(/index.html$/, "")
     end
   end


### PR DESCRIPTION
I think this might be something that broke with the latest releases of jekyll but I had to remove the dir otherwise my URLs were:

/docs/dev/docs/dev/ instead of /docs/dev/

Willing to test other fixes but this works for me.

Thanks!
