### PR TITLE
Adding chomp_html option to remove the .html suffix from the generated u...

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,13 @@ sitemap:
         - "/index.html"
     change_frequency_name: "change_frequency"
     priority_name: "priority"
+    chomp_html: false
 ```
 
 Customizations:
 ---------------
 If you want to include the optional changefreq and priority attributes, simply include custom variables in the YAML Front Matter of those files. The names of these custom variables are defined in the config file as `sitemap: change_frequency_name:` and `sitemap: priority_name:`.
+Set `chomp_html: true` if you prefer url's without the .html suffix.
 
 Notes:
 ------

--- a/sitemap_generator.rb
+++ b/sitemap_generator.rb
@@ -75,6 +75,7 @@ module Jekyll
     INCLUDE_POSTS = ["/index.html"] 
     CHANGE_FREQUENCY_NAME = "change_frequency"
     PRIORITY_NAME = "priority"
+    CHOMP_HTML = false
     
     # Valid values allowed by sitemap.xml spec for change frequencies
     VALID_CHANGE_FREQUENCY_VALUES = ["always", "hourly", "daily", "weekly",
@@ -92,6 +93,7 @@ module Jekyll
       @config['priority_name'] = sitemap_config['priority_name'] || PRIORITY_NAME
       @config['exclude'] = sitemap_config['exclude'] || EXCLUDE
       @config['include_posts'] = sitemap_config['include_posts'] || INCLUDE_POSTS
+      @config['chomp_html'] = sitemap_config['chomp_html'] || CHOMP_HTML
 
       sitemap = REXML::Document.new << REXML::XMLDecl.new("1.0", "UTF-8")
 
@@ -203,7 +205,9 @@ module Jekyll
       loc = REXML::Element.new "loc"
       url = site.config['url']
       loc.text = page_or_post.location_on_server(url)
-
+      if (@config['chomp_html'] == true)
+        loc.text = loc.text.chomp(".html")
+      end
       loc
     end
 


### PR DESCRIPTION
I have added an option to remove the .html from the generated url's because I am deploying to an apache server and I am rewriting my url's.
I guess I'm not the only one with that setup.
