### PR TITLE
this fix prevents sitemap.xml from being deleted

### DIFF
--- a/sitemap_generator.rb
+++ b/sitemap_generator.rb
@@ -58,11 +58,6 @@ module Jekyll
   # Recover from strange exception when starting server without --auto
   class SitemapFile < StaticFile
     def write(dest)
-      begin
-        super(dest)
-      rescue
-      end
-
       true
     end
   end


### PR DESCRIPTION
Hi,

I am using Jekyll 2.1.1 (latest version) and some changes in the recent code of Jekyll::StaticFile (https://github.com/jekyll/jekyll/commit/74f0f27d18571d41eb6988a2f1e72c19c22f4c73) prevent the plugin from generating the "sitemap.xml" file.

This is the backtrace I got:

/home/danfran/.rvm/rubies/ruby-2.1.1/lib/ruby/2.1.0/fileutils.rb:1573:in `stat'
/home/danfran/.rvm/rubies/ruby-2.1.1/lib/ruby/2.1.0/fileutils.rb:1573:in`block in fu_each_src_dest'
/home/danfran/.rvm/rubies/ruby-2.1.1/lib/ruby/2.1.0/fileutils.rb:1589:in `fu_each_src_dest0'
/home/danfran/.rvm/rubies/ruby-2.1.1/lib/ruby/2.1.0/fileutils.rb:1571:in`fu_each_src_dest'
/home/danfran/.rvm/rubies/ruby-2.1.1/lib/ruby/2.1.0/fileutils.rb:399:in `cp'
/home/danfran/.rvm/gems/ruby-2.1.1/gems/jekyll-2.1.1/lib/jekyll/static_file.rb:63:in`write'
/home/danfran/Dropbox/My Site/_plugins/sitemap_generator.rb:63:in `write'

In my commit I removed the call to the method that generates the problem. Actually it is not required to call that method as in the plugin the file is already generated in site.dest.

Another possible solution is using for the temporary file "site.source" (or a tmp path), and leaving the call to the method above.
