### PR TITLE
Set priority so it runs after other generators

### DIFF
--- a/sitemap_generator.rb
+++ b/sitemap_generator.rb
@@ -63,6 +63,7 @@ module Jekyll
   end
 
   class SitemapGenerator < Generator
+    priority :lowest
 
     # Config defaults
     SITEMAP_FILE_NAME = "/sitemap.xml"


### PR DESCRIPTION
Using the ":lowest" priority (http://jekyllrb.com/docs/plugins/#flags) this generator is more likely to run after other generators so that their pages get included in the sitemap.
