### PR TITLE
Add support for directories in "exclude"

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ How To Use:
 1. Copy file into your _plugins folder within your Jekyll project.
 2. Ensure url is set in your config file (for example `url: http://danielgroves.net`)
 3. In your config file, change `sitemap: file:` if you want your sitemap to be called something other than sitemap.xml.
-4. Change the `sitemap: exclude:` list to exclude any pages that you don't want in the sitemap. 
+4. Change the `sitemap: exclude:` list to exclude any pages or directory that you don't want in the sitemap. 
 5. Change the `sitemap: include_posts:` list to include any pages that are looping through your posts (e.g. "/index.html", "/notebook/index.md", etc.). This will ensure that right after you make a new post, the last modified date will be updated to reflect the new post.
 6. Run Jekyll: `jekyll` to re-generate your site.
 7. A `sitemap.xml` should be included in your _site folder.
@@ -22,6 +22,7 @@ sitemap:
         - "/atom.xml"
         - "/feed.xml"
         - "/feed/index.xml"
+        - "/images/"
     include_posts:
         - "/index.html"
     change_frequency_name: "change_frequency"

--- a/sitemap_generator.rb
+++ b/sitemap_generator.rb
@@ -263,7 +263,7 @@ module Jekyll
     #
     # Returns boolean
     def excluded?(site, name)
-      @config['exclude'].include? name
+      @config['exclude'].any? { |i| name.index(i) == 0 }
     end
 
     def posts_included?(site, name)


### PR DESCRIPTION
It is often useful to exclude an entire part of the hierarchy from
the sitemap, and this change lets you do that. The approach is
very basic, and could generate false positives if you want to include
foobar.html but exclude foobar.htm, but for the general case, it works.